### PR TITLE
Add serif circle digit styles and improve fallback behavior

### DIFF
--- a/digit.tmux
+++ b/digit.tmux
@@ -2,6 +2,8 @@
 # shellcheck disable=SC2155,SC2034
 digits_circle=(⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨ ⑩ ⑪ ⑫ ⑬ ⑭ ⑮ ⑯ ⑰ ⑱ ⑲ ⑳)
 digits_circle_inv=(0 󰲠 󰲢 󰲤 󰲦 󰲨 󰲪 󰲬 󰲮 󰲰)
+digits_circle_serif=("🄋 " "➀ " "➁ " "➂ " "➃ " "➄ " "➅ " "➆ " "➇ " "➈ " "➉ ")
+digits_circle_serif_inv=("🄌 " "➊ " "➋ " "➌ " "➍ " "➎ " "➏ " "➐ " "➑ " "➒ " "➓ ")
 digits_square=(󰎣 󰎦 󰎩 󰎬 󰎮 󰎰 󰎵 󰎸 󰎻 󰎾)
 digits_square_inv=(󰎡 󰎤 󰎧 󰎪 󰎭 󰎱 󰎳 󰎶 󰎹 󰎼)
 digits_layer=(󰎢 󰎥 󰎨 󰎫 󰎲 󰎯 󰎴 󰎷 󰎺 󰎽)
@@ -12,15 +14,19 @@ interpolation=(
 	"#S"
 	"#I"
 )
-
 get_command() {
-	local name="$1"
-	local -i i=0
-	shift
-	for digit; do
-		echo -n "#{?#{==:#$name,$i},$digit,}"
-		i=$((i + 1))
-	done
+  local name="$1"
+  shift
+
+  local expr="#$name"
+
+  local i=0
+  for digit; do
+    expr="#{?#{==:#$name,$i},$digit,$expr}"
+    i=$((i + 1))
+  done
+
+  printf '%s' "$expr"
 }
 
 get_tmux_option() {

--- a/digit.tmux
+++ b/digit.tmux
@@ -15,18 +15,18 @@ interpolation=(
 	"#I"
 )
 get_command() {
-  local name="$1"
-  shift
+	local name="$1"
+	shift
 
-  local expr="#$name"
+	local expr="#$name"
 
-  local i=0
-  for digit; do
-    expr="#{?#{==:#$name,$i},$digit,$expr}"
-    i=$((i + 1))
-  done
+	local i=0
+	for digit; do
+		expr="#{?#{==:#$name,$i},$digit,$expr}"
+		i=$((i + 1))
+	done
 
-  printf '%s' "$expr"
+	printf '%s' "$expr"
 }
 
 get_tmux_option() {

--- a/digit.tmux
+++ b/digit.tmux
@@ -2,8 +2,12 @@
 # shellcheck disable=SC2155,SC2034
 digits_circle=(⓪ ① ② ③ ④ ⑤ ⑥ ⑦ ⑧ ⑨ ⑩ ⑪ ⑫ ⑬ ⑭ ⑮ ⑯ ⑰ ⑱ ⑲ ⑳)
 digits_circle_inv=(0 󰲠 󰲢 󰲤 󰲦 󰲨 󰲪 󰲬 󰲮 󰲰)
+
+# Trailing spaces after each digit are intentional to fix glyph rendering issues
+# in certain terminals with Nerd Fonts (prevents extremely small rendering)
 digits_circle_serif=("🄋 " "➀ " "➁ " "➂ " "➃ " "➄ " "➅ " "➆ " "➇ " "➈ " "➉ ")
 digits_circle_serif_inv=("🄌 " "➊ " "➋ " "➌ " "➍ " "➎ " "➏ " "➐ " "➑ " "➒ " "➓ ")
+
 digits_square=(󰎣 󰎦 󰎩 󰎬 󰎮 󰎰 󰎵 󰎸 󰎻 󰎾)
 digits_square_inv=(󰎡 󰎤 󰎧 󰎪 󰎭 󰎱 󰎳 󰎶 󰎹 󰎼)
 digits_layer=(󰎢 󰎥 󰎨 󰎫 󰎲 󰎯 󰎴 󰎷 󰎺 󰎽)


### PR DESCRIPTION
## Summary

This PR adds two new digit styles and improves robustness when interpolating tmux variables.

### ✔ New styles
- `circle_serif`
- `circle_serif_inv`

### ✔ Behavior improvement
`get_command` now falls back to the original tmux format (`#S`, `#I`) when no digit mapping applies, rather than expanding to an empty string.

## Why

### The `get_command`

The previous implementation expanded to an empty string when the value of #S or #I was outside the range of the digit array (e.g. for named sessions or high indices). The change improves that behavior by falling back to the original tmux variable (#S, #I), which keeps the status line predictable and readable in all cases.

### Serif-based circle digits fix rendering issues across terminals and Nerd Fonts

The standard circled digits (`① ② ③ …`) render much smaller in several terminals when using certain Nerd Fonts. This makes session/index numbers appear tiny or misaligned in the tmux status line.

This issue appears in:

- **kitty** (Iosevka Nerd Font, JetBrains Nerd Font, Hack Nerd Font)
- **Ghostty** (Iosevka Nerd Font Mono, JetBrains Nerd Font, Hack Nerd Font)

Meanwhile, in **WezTerm** and **Alacritty**, the same fonts render the standard digits correctly — so the issue is font + renderer specific.

The new serif-based circled digits (`➀ ➁ ➂ …`) maintain consistent glyph metrics across all these environments, fixing the readability issue.

#### Example (depends on font/terminal):

<img width="461" height="68" alt="immagine" src="https://github.com/user-attachments/assets/b2e1fee3-4938-421f-aaea-2404b2f5ebfe" />

#### Standard
<img width="184" height="19" alt="immagine" src="https://github.com/user-attachments/assets/21084979-8c9c-4942-8ef9-67b54a85ecbc" />

vs

#### Sans-serif
<img width="201" height="19" alt="immagine" src="https://github.com/user-attachments/assets/ea3cdaee-d477-4392-a5b5-6298a163ca56" />

## Changes

### 1. New digit style arrays

- `digits_circle_serif=("🄋 " "➀ " "➁ " "➂ " "➃ " "➄ " "➅ " "➆ " "➇ " "➈ " "➉ ")`
- `digits_circle_serif_inv=("🄌 " "➊ " "➋ " "➌ " "➍ " "➎ " "➏ " "➐ " "➑ " "➒ " "➓ ")`

Selectable via:

```tmux
set -g @digit-style 'circle_serif'
set -g @digit-style 'circle_serif_inv'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two circular serif digit display styles for enhanced visual options.

* **Performance**
  * Consolidated command-generation to produce a single assembled output, reducing redundant intermediate output and improving efficiency.

* **Bug Fixes**
  * Adjusted spacing in digit glyphs to address rendering issues in some Nerd Font terminals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->